### PR TITLE
Update LiveDNS endpoint and the docs URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,20 +7,20 @@ This package implements the [libdns interfaces](https://github.com/libdns/libdns
 
 ## Authenticating
 
-This package supports **API Key authentication** but does not yet support **Sharing ID authentication**. Refer to the [LiveDNS documentation](https://doc.livedns.gandi.net/) for more information.
+This package only supports **API Key authentication**. Refer to the [Gandi's Public API documentation](https://api.gandi.net/docs/reference/#Authentication) for more information.
 
 Start by [retrieving your API key](https://account.gandi.net/) from the _Security_ section in Gandi account admin panel to be able to make authenticated requests to the API.
 
 ## Technical limitations
 
-The [LiveDNS documentation](https://doc.livedns.gandi.net/) states that records with the same name and type are merged so that their `rrset_values` are grouped together.
+The [LiveDNS documentation](https://api.gandi.net/docs/livedns/) states that records with the same name and type are merged so that their `rrset_values` are grouped together.
 
 ```
 {
   "rrset_type": "MX",
   "rrset_ttl": 1800,
   "rrset_name": "@",
-  "rrset_href": "https://dns.api.gandi.net/api/v5/domains/gconfs.fr/records/@/MX",
+  "rrset_href": "https://api.gandi.net/v5/livedns/domains/gconfs.fr/records/@/MX",
   "rrset_values": [
     "1 aspmx.l.google.com.",
     "5 alt1.aspmx.l.google.com.",

--- a/client.go
+++ b/client.go
@@ -157,7 +157,7 @@ func (p *Provider) getDomain(ctx context.Context, zone string) (gandiDomain, err
 }
 
 func (p *Provider) doRequest(req *http.Request, result interface{}) (gandiStatus, error) {
-	req.Header.Set("X-Api-Key", p.APIToken)
+	req.Header.Set("Authorization", fmt.Sprintf("Apikey %s", p.APIToken))
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)

--- a/client.go
+++ b/client.go
@@ -143,7 +143,7 @@ func (p *Provider) getDomain(ctx context.Context, zone string) (gandiDomain, err
 		return domain, nil
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("https://dns.api.gandi.net/api/v5/domains/%s", fqdn), nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("https://api.gandi.net/v5/livedns/domains/%s", fqdn), nil)
 
 	var domain gandiDomain
 

--- a/gandi.go
+++ b/gandi.go
@@ -31,19 +31,17 @@ type gandiZone struct {
 }
 
 type gandiDomain struct {
-	ZoneUUID           string `json:"zone_uuid"`
-	DomainKeysHref     string `json:"domain_keys_href"`
 	Fqdn               string `json:"fqdn"`
-	ZoneHref           string `json:"zone_href"`
 	AutomaticSnapshots bool   `json:"automatic_snapshots"`
-	ZoneRecordsHref    string `json:"zone_records_href"`
-	DomainRecordsHref  string `json:"domain_records_href"`
 	DomainHref         string `json:"domain_href"`
+	DomainKeysHref     string `json:"domain_keys_href"`
+	DomainRecordsHref  string `json:"domain_records_href"`
 }
 
 type gandiRecord struct {
-	RRSetType   string   `json:"rrset_type,omitempty"`
-	RRSetTTL    int      `json:"rrset_ttl,omitempty"`
+	RRSetHref   string   `json:"rrset_href,omitempty"`
 	RRSetName   string   `json:"rrset_name,omitempty"`
+	RRSetType   string   `json:"rrset_type,omitempty"`
 	RRSetValues []string `json:"rrset_values,omitempty"`
+	RRSetTTL    int      `json:"rrset_ttl,omitempty"`
 }

--- a/provider.go
+++ b/provider.go
@@ -24,7 +24,7 @@ func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record
 		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "GET", domain.ZoneRecordsHref, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", domain.DomainRecordsHref, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Since April 2020 we (Gandi) have deprecated the old LiveDNS endpoint in favor of the new one that is part of our public API project.

This PR update the endpoint but also the link to the new documentation.

cc @grigouze @romuald