### PR TITLE
Preserve original record name and don't add a "." suffix

### DIFF
--- a/client.go
+++ b/client.go
@@ -15,10 +15,7 @@ func (p *Provider) setRecord(ctx context.Context, zone string, record libdns.Rec
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
-	// Append a dot to get the absolute record name.
-	recAbsoluteName := record.Name + "."
-
-	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/%s/%s", domain.DomainRecordsHref, recAbsoluteName, record.Type), nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/%s/%s", domain.DomainRecordsHref, record.Name, record.Type), nil)
 	if err != nil {
 		return err
 	}
@@ -49,7 +46,7 @@ func (p *Provider) setRecord(ctx context.Context, zone string, record libdns.Rec
 	newGandiRecord := gandiRecord{
 		RRSetTTL:    int(record.TTL.Seconds()),
 		RRSetType:   record.Type,
-		RRSetName:   recAbsoluteName,
+		RRSetName:   record.Name,
 		RRSetValues: recValues,
 	}
 
@@ -59,7 +56,7 @@ func (p *Provider) setRecord(ctx context.Context, zone string, record libdns.Rec
 	}
 
 	// we update existing record or create a new record if it does not exist yet
-	req, err = http.NewRequestWithContext(ctx, "PUT", fmt.Sprintf("%s/%s/%s", domain.DomainRecordsHref, recAbsoluteName, record.Type), bytes.NewReader(raw))
+	req, err = http.NewRequestWithContext(ctx, "PUT", fmt.Sprintf("%s/%s/%s", domain.DomainRecordsHref, record.Name, record.Type), bytes.NewReader(raw))
 	if err != nil {
 		return err
 	}
@@ -75,10 +72,7 @@ func (p *Provider) deleteRecord(ctx context.Context, zone string, record libdns.
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
-	// Append a dot to get the absolute record name.
-	recAbsoluteName := record.Name + "."
-
-	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/%s/%s", domain.DomainRecordsHref, recAbsoluteName, record.Type), nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/%s/%s", domain.DomainRecordsHref, record.Name, record.Type), nil)
 	if err != nil {
 		return err
 	}
@@ -104,7 +98,7 @@ func (p *Provider) deleteRecord(ctx context.Context, zone string, record libdns.
 			return err
 		}
 
-		req, err = http.NewRequestWithContext(ctx, "PUT", fmt.Sprintf("%s/%s/%s", domain.DomainRecordsHref, recAbsoluteName, record.Type), bytes.NewReader(raw))
+		req, err = http.NewRequestWithContext(ctx, "PUT", fmt.Sprintf("%s/%s/%s", domain.DomainRecordsHref, record.Name, record.Type), bytes.NewReader(raw))
 	} else {
 		// if there is only one entry, we make sure that the value to delete is matching the one we found
 		// otherwise we may delete the wrong record
@@ -112,7 +106,7 @@ func (p *Provider) deleteRecord(ctx context.Context, zone string, record libdns.
 			return fmt.Errorf("LiveDNS returned a %v (%v)", http.StatusNotFound, "Can't find such a DNS value")
 		}
 
-		req, err = http.NewRequestWithContext(ctx, "DELETE", fmt.Sprintf("%s/%s/%s", domain.DomainRecordsHref, recAbsoluteName, record.Type), nil)
+		req, err = http.NewRequestWithContext(ctx, "DELETE", fmt.Sprintf("%s/%s/%s", domain.DomainRecordsHref, record.Name, record.Type), nil)
 	}
 
 	// we check if NewRequestWithContext threw an error


### PR DESCRIPTION
The record name should not contain a dot at the end, because it's a relative name. The Gandi API doesn't seem to accept that anymore.

With the old code lately I would get errors like this:

```Absolute rrset_name must end with <redacted domain>. (_acme-challenge.mx.)```