### PR TITLE
fix(GetRecords): return typed libdns records for caddy-dynamicdns

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -38,14 +38,17 @@ func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record
 	var libRecords []libdns.Record
 	for _, rec := range gandiRecords {
 		for _, val := range rec.RRSetValues {
-			rec := libdns.RR{
+			rr := libdns.RR{
 				Type: rec.RRSetType,
 				Name: rec.RRSetName,
 				TTL:  time.Duration(rec.RRSetTTL) * time.Second,
 				Data: val,
 			}
-
-			libRecords = append(libRecords, rec)
+			parsed, err := rr.Parse()
+			if err != nil {
+				return nil, err
+			}
+			libRecords = append(libRecords, parsed)
 		}
 	}
 


### PR DESCRIPTION
[caddy-dynamicdns#85](https://github.com/mholt/caddy-dynamicdns/pull/85) changed `lookupCurrentIPsFromDNS` to only accept **`libdns.Address`**:
```go
ar, ok := r.(libdns.Address)
if !ok {
    continue
}
```

Previously, dynamic_dns parsed A/AAAA from generic record fields (Type, Value, etc.). After the upgrade it relies on providers returning the standard typed structs from GetRecords.
